### PR TITLE
Fix the snippet in the installation guide

### DIFF
--- a/guides/getting-started/installation.md
+++ b/guides/getting-started/installation.md
@@ -116,9 +116,9 @@ def index
   posts = PostResource.all(params)
 
   respond_to do |format|
-    format.json { render(json: posts.to_json) }
-    format.jsonapi { render(jsonapi: posts.to_jsonapi) }
-    format.xml { render(xml: posts.to_xml) }
+    format.json { render(json: posts) }
+    format.jsonapi { render(jsonapi: posts) }
+    format.xml { render(xml: posts) }
   end
 end
 {% endhighlight %}


### PR DESCRIPTION
- the #to_json and #to_xml calls weren't doing any harm but were excessive
- the #to_jsonapi part attempted to call #to_jsonapi on an already serialised string and failed with an error

The updated snippet seem to be compatible with [the code created by graphiti-rails generator](https://github.com/graphiti-api/graphiti-rails/blob/684b1d8c1cf497fbccc4e2b08fde2734338f16b4/lib/generators/graphiti/templates/controller.rb.erb#L9)
