### PR TITLE
Make `SomeResource.find` docs/api a bit clearer

### DIFF
--- a/guides/concepts/resources.md
+++ b/guides/concepts/resources.md
@@ -394,6 +394,8 @@ employee = EmployeeResource.find(id: 123)
 employee.data.first_name # => "Jane"
 {% endhighlight %}
 
+*Note*: `SomeResource.find` returns a `ResourceProxy`. To access the model/record proper you will want to make sure you call `.data` on the result of find as shown above.
+
 {% include h.html tag="h3" text="3.2 Composing with Scopes" a="composing-with-scopes" %}
 
 {% include h.html tag="h4" text="3.2.1 #base_scope" a="base-scope" %}


### PR DESCRIPTION
A concern was raised around what `find` returns in https://github.com/graphiti-api/graphiti/issues/170. The change here calls out explicitly what `find` returns and how to access to model proper.