### PR TITLE
[resources] Add Documentation around new writable/readable flags

### DIFF
--- a/guides/concepts/resources.md
+++ b/guides/concepts/resources.md
@@ -394,6 +394,8 @@ employee = EmployeeResource.find(id: 123)
 employee.data.first_name # => "Jane"
 {% endhighlight %}
 
+*Note*: `SomeResource.find` returns a `ResourceProxy`. To access the model/record proper you will want to make sure you call `.data` on the result of find as shown above.
+
 {% include h.html tag="h3" text="3.2 Composing with Scopes" a="composing-with-scopes" %}
 
 {% include h.html tag="h4" text="3.2.1 #base_scope" a="base-scope" %}

--- a/guides/concepts/resources.md
+++ b/guides/concepts/resources.md
@@ -928,6 +928,30 @@ has_many :positions,
   single: false # only allow this sideload when one employee
 {% endhighlight %}
 
+For the `readable` and `writable` flags you can pass a symbol, block, string, or boolean value. Below are some examples:
+
+{% highlight ruby %}
+# This expects the methods `user_can_read?` and `user_can_write?` to be defined on your resource. 
+# Blocks are evaluated in the context of a resource instance.
+has_many :positions,
+  readable: lambda{ user_can_read? },
+  writable: lambda{ user_can_write? }
+{% endhighlight %}
+
+{% highlight ruby %}
+# This expects the symbols to be methods defined on your resource. 
+has_many :positions,
+  readable: :user_can_read?,
+  writable: :user_can_write?
+{% endhighlight %}
+
+{% highlight ruby %}
+# This expects the strings to be methods defined on your resource. 
+has_many :positions,
+  readable: "user_can_read?",
+  writable: "user_can_write?"
+{% endhighlight %}
+
 {% include h.html tag="h5" text="5.2.1 Customizing Scope" a="customizing-scope" %}
 
 Use `params` to change the query parameters that will be passed to the


### PR DESCRIPTION
A recent PR granted Graphiti the capability to pass symbols, strings, and blocks in addition to booleans for the `readable` and `writable` flags. This allows clients to more dynamically evaluate if a specific resource should have access based on permissions or other, more dynamic conditions.