### PR TITLE
Update theme to make quotation marks more visible

### DIFF
--- a/_sass/theme.scss
+++ b/_sass/theme.scss
@@ -703,7 +703,7 @@ img[alt=glimmer_logo] {
       color: white;
     }
 
-    .s1, .s2 {
+    .s1, .s2, .dl {
       color: lightgreen;
       font-weight: 600;
     }


### PR DESCRIPTION
Current behavior: single and double quotation marks are dark grey on a dark grey background.

Proposed change: use same color as .s1/.s2 classes, typical behavior for text editors and IDEs.