### PR TITLE
Fix testing navigation

### DIFF
--- a/_site/guides/concepts/testing.html
+++ b/_site/guides/concepts/testing.html
@@ -151,7 +151,7 @@
     <li>5 <a href="#context">Context</a></li>
     <li>6 <a href="#schema-validation">Schema Validation</a></li>
     <li>7 <a href="#testing-spectrum">Testing Spectrum</a></li>
-    <li>8 <a href="double-testing-units">Double-Testing Units</a></li>
+    <li>8 <a href="#double-testing-units">Double-Testing Units</a></li>
     <li>9 <a href="#generators">Generators</a></li>
   </ul>
 

--- a/guides/concepts/testing.md
+++ b/guides/concepts/testing.md
@@ -43,7 +43,7 @@ Testing
 * 5 [Context](#context)
 * 6 [Schema Validation](#schema-validation)
 * 7 [Testing Spectrum](#testing-spectrum)
-* 8 [Double-Testing Units](double-testing-units)
+* 8 [Double-Testing Units](#double-testing-units)
 * 9 [Generators](#generators)
 
 </div>


### PR DESCRIPTION
One of the navigation items was missing the hash character so
clicking the link took to a 404 page.