### PR TITLE
Add documentation for using `Authorisation headers` in rake taks

### DIFF
--- a/_site/guides/concepts/debugging.html
+++ b/_site/guides/concepts/debugging.html
@@ -94,7 +94,7 @@
       <ul>
         <li><a href="#graphiti-request">graphiti:request</a></li>
         <li><a href="#graphiti-benchmark">graphiti:benchmark</a></li>
-        <li><a href="#authorisation-headers">Authorisation headers</a></li>
+        <li><a href="#Authorization-headers">Authorization headers</a></li>
       </ul>
     </li>
     <li>3 <a href="#tips">Tips</a></li>
@@ -302,14 +302,14 @@ server, to eliminate the vagaries of latency. To do this:</p>
 
   <p>Which will return the average response time.</p>
 
-<a class="anchor" id="authorisation-headers" />
-  <a class="header" href="#authorisation-headers">
+<a class="anchor" id="Authorization-headers" />
+  <a class="header" href="#Authorization-headers">
     <h4>
-      2.3 Authorisation headers
+      2.3 Authorization headers
     </h4>
   </a>
 
-  <p>If you have an authorisation scheme implemented (for example <a href="https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html">authenticate_or_request_with_http_token</a> in rails) you can supply the <code class="highlighter-rouge">Authorization</code> http header value with the <code class="highlighter-rouge">AUTHORIZATION_HEADER</code> environment variable:</p>
+  <p>If you have an Authorization scheme implemented (for example <a href="https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html">authenticate_or_request_with_http_token</a> in rails) you can supply the <code class="highlighter-rouge">Authorization</code> http header value with the <code class="highlighter-rouge">AUTHORIZATION_HEADER</code> environment variable:</p>
 
   <figure class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span><span class="nb">export </span><span class="nv">AUTHORIZATION_HEADER</span><span class="o">=</span><span class="s2">"Token --PRIVATE_API_KEY--"</span>
 <span class="gp">$ </span>bin/rake graphiti:request[/employees,true]</code></pre></figure>

--- a/_site/guides/concepts/debugging.html
+++ b/_site/guides/concepts/debugging.html
@@ -309,7 +309,7 @@ server, to eliminate the vagaries of latency. To do this:</p>
     </h4>
   </a>
 
-  <p>If you have an autorisation scheme implemented (for example <a href="https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html">authenticate_or_request_with_http_token</a> in rails) you can supply the <code class="highlighter-rouge">Authorization</code> http header value with the <code class="highlighter-rouge">AUTHORIZATION_HEADER</code> environment variable:</p>
+  <p>If you have an authorisation scheme implemented (for example <a href="https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html">authenticate_or_request_with_http_token</a> in rails) you can supply the <code class="highlighter-rouge">Authorization</code> http header value with the <code class="highlighter-rouge">AUTHORIZATION_HEADER</code> environment variable:</p>
 
   <figure class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span><span class="nb">export </span><span class="nv">AUTHORIZATION_HEADER</span><span class="o">=</span><span class="s2">"Token --PRIVATE_API_KEY--"</span>
 <span class="gp">$ </span>bin/rake graphiti:request[/employees,true]</code></pre></figure>

--- a/_site/guides/concepts/debugging.html
+++ b/_site/guides/concepts/debugging.html
@@ -94,6 +94,7 @@
       <ul>
         <li><a href="#graphiti-request">graphiti:request</a></li>
         <li><a href="#graphiti-benchmark">graphiti:benchmark</a></li>
+        <li><a href="#authorisation-headers">Authorisation headers</a></li>
       </ul>
     </li>
     <li>3 <a href="#tips">Tips</a></li>
@@ -300,6 +301,20 @@ server, to eliminate the vagaries of latency. To do this:</p>
   <figure class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>bin/rake graphiti:benchmark[/employees,100]</code></pre></figure>
 
   <p>Which will return the average response time.</p>
+
+<a class="anchor" id="authorisation-headers" />
+  <a class="header" href="#authorisation-headers">
+    <h4>
+      2.3 Authorisation headers
+    </h4>
+  </a>
+
+  <p>If you have an autorisation scheme implemented (for example <a href="https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html">authenticate_or_request_with_http_token</a> in rails) you can supply the <code class="highlighter-rouge">Authorization</code> http header value with the <code class="highlighter-rouge">AUTHORIZATION_HEADER</code> environment variable:</p>
+
+  <figure class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span><span class="nb">export </span><span class="nv">AUTHORIZATION_HEADER</span><span class="o">=</span><span class="s2">"Token --PRIVATE_API_KEY--"</span>
+<span class="gp">$ </span>bin/rake graphiti:request[/employees,true]</code></pre></figure>
+
+  <p>This also will work for <code class="highlighter-rouge">Basic</code> (<a href="https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic.html$$">request_http_basic_authentication</a>) and <code class="highlighter-rouge">Bearer</code> values</p>
 
 <a class="anchor" id="tips" />
   <a class="header" href="#tips">

--- a/guides/concepts/debugging.md
+++ b/guides/concepts/debugging.md
@@ -12,6 +12,7 @@ Debugging
 * 2 [Rake Tasks](#rake-tasks)
   * [graphiti:request](#graphiti-request)
   * [graphiti:benchmark](#graphiti-benchmark)
+  * [Authorisation headers](#authorisation-headers)
 * 3 [Tips](#tips)
 
 </div>
@@ -201,6 +202,17 @@ $ bin/rake graphiti:benchmark[/employees,100]
 {% endhighlight %}
 
 Which will return the average response time.
+
+{% include h.html tag="h4" text="2.3 Authorisation headers" a="authorisation-headers" %}
+
+If you have an autorisation scheme implemented (for example [authenticate_or_request_with_http_token](https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html) in rails) you can supply the `Authorization` http header value with the `AUTHORIZATION_HEADER` environment variable:
+
+{% highlight bash %}
+$ export AUTHORIZATION_HEADER="Token --PRIVATE_API_KEY--"
+$ bin/rake graphiti:request[/employees,true]
+{% endhighlight %}
+
+This also will work for `Basic` ([request_http_basic_authentication](https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic.html$$)) and `Bearer` values
 
 {% include h.html tag="h2" text="3 Tips" a="tips" %}
 

--- a/guides/concepts/debugging.md
+++ b/guides/concepts/debugging.md
@@ -12,7 +12,7 @@ Debugging
 * 2 [Rake Tasks](#rake-tasks)
   * [graphiti:request](#graphiti-request)
   * [graphiti:benchmark](#graphiti-benchmark)
-  * [Authorisation headers](#authorisation-headers)
+  * [Authorization headers](#Authorization-headers)
 * 3 [Tips](#tips)
 
 </div>
@@ -203,9 +203,9 @@ $ bin/rake graphiti:benchmark[/employees,100]
 
 Which will return the average response time.
 
-{% include h.html tag="h4" text="2.3 Authorisation headers" a="authorisation-headers" %}
+{% include h.html tag="h4" text="2.3 Authorization headers" a="Authorization-headers" %}
 
-If you have an authorisation scheme implemented (for example [authenticate_or_request_with_http_token](https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html) in rails) you can supply the `Authorization` http header value with the `AUTHORIZATION_HEADER` environment variable:
+If you have an Authorization scheme implemented (for example [authenticate_or_request_with_http_token](https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html) in rails) you can supply the `Authorization` http header value with the `AUTHORIZATION_HEADER` environment variable:
 
 {% highlight bash %}
 $ export AUTHORIZATION_HEADER="Token --PRIVATE_API_KEY--"

--- a/guides/concepts/debugging.md
+++ b/guides/concepts/debugging.md
@@ -205,7 +205,7 @@ Which will return the average response time.
 
 {% include h.html tag="h4" text="2.3 Authorisation headers" a="authorisation-headers" %}
 
-If you have an autorisation scheme implemented (for example [authenticate_or_request_with_http_token](https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html) in rails) you can supply the `Authorization` http header value with the `AUTHORIZATION_HEADER` environment variable:
+If you have an authorisation scheme implemented (for example [authenticate_or_request_with_http_token](https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html) in rails) you can supply the `Authorization` http header value with the `AUTHORIZATION_HEADER` environment variable:
 
 {% highlight bash %}
 $ export AUTHORIZATION_HEADER="Token --PRIVATE_API_KEY--"


### PR DESCRIPTION
 Related to graphiti-api/graphiti-rails#70