### PR TITLE
fix: Add default option `always_include_resource_ids: false` to has_many/belongs_to

### DIFF
--- a/_site/guides/concepts/resources.html
+++ b/_site/guides/concepts/resources.html
@@ -1096,8 +1096,11 @@ also pass the JSONAPI type in brackets:</p>
   <span class="ss">resource: </span><span class="no">EmployeeResource</span><span class="p">,</span>
   <span class="ss">readable: </span><span class="kp">true</span><span class="p">,</span>
   <span class="ss">writable: </span><span class="kp">true</span><span class="p">,</span>
-  <span class="ss">link: </span><span class="nb">self</span><span class="p">.</span><span class="nf">autolink</span> <span class="c1"># default true</span>
-  <span class="ss">single: </span><span class="kp">false</span> <span class="c1"># only allow this sideload when one employee</span></code></pre></figure>
+  <span class="ss">link: </span><span class="nb">self</span><span class="p">.</span><span class="nf">autolink</span><span class="p">,</span> <span class="c1"># default true</span>
+  <span class="ss">single: </span><span class="kp">false</span><span class="p">,</span> <span class="c1"># only allow this sideload when one employee</span>
+  <span class="ss">always_include_resource_ids: </span><span class="kp">false</span></code></pre></figure>
+
+  <p><em>note</em>: Setting <code class="highlighter-rouge">always_include_resource_ids: true</code> could result in 1+N queries (see <a href="https://github.com/graphiti-api/graphiti/issues/167#issuecomment-686866646">#167</a>)</p>
 
 <a class="anchor" id="customizing-scope" />
   <a class="header" href="#customizing-scope">
@@ -1183,6 +1186,7 @@ care of this for you.</p>
   <figure class="highlight"><pre><code class="language-ruby" data-lang="ruby"><span class="n">has_many</span> <span class="ss">:positions</span><span class="p">,</span>
   <span class="ss">foreign_key: :employee_id</span><span class="p">,</span>
   <span class="ss">primary_key: :id</span><span class="p">,</span>
+  <span class="ss">always_include_resource_ids: </span><span class="kp">false</span><span class="p">,</span>
   <span class="ss">resource: </span><span class="no">PositionResource</span></code></pre></figure>
 
   <p>Which would cause the following query when sideloading:</p>
@@ -1221,6 +1225,7 @@ would be associated with logic similar to:</p>
   <figure class="highlight"><pre><code class="language-ruby" data-lang="ruby"><span class="n">belongs_to</span> <span class="ss">:employee</span><span class="p">,</span>
   <span class="ss">foreign_key: :employee_id</span><span class="p">,</span>
   <span class="ss">primary_key: :id</span><span class="p">,</span>
+  <span class="ss">always_include_resource_ids: </span><span class="kp">false</span><span class="p">,</span>
   <span class="ss">resource: </span><span class="no">EmployeeResource</span></code></pre></figure>
 
   <p>Which would cause the following query when sideloading:</p>

--- a/guides/concepts/resources.md
+++ b/guides/concepts/resources.md
@@ -935,9 +935,12 @@ has_many :positions,
   resource: EmployeeResource,
   readable: true,
   writable: true,
-  link: self.autolink # default true
-  single: false # only allow this sideload when one employee
+  link: self.autolink, # default true
+  single: false, # only allow this sideload when one employee
+  always_include_resource_ids: false
 {% endhighlight %}
+
+*note*: Setting `always_include_resource_ids: true` could result in 1+N queries (see [#167](https://github.com/graphiti-api/graphiti/issues/167#issuecomment-686866646))
 
 {% include h.html tag="h5" text="5.2.1 Customizing Scope" a="customizing-scope" %}
 
@@ -1021,6 +1024,7 @@ Defaults to these common options:
 has_many :positions,
   foreign_key: :employee_id,
   primary_key: :id,
+  always_include_resource_ids: false,
   resource: PositionResource
 {% endhighlight %}
 
@@ -1064,6 +1068,7 @@ Defaults to these common options:
 belongs_to :employee,
   foreign_key: :employee_id,
   primary_key: :id,
+  always_include_resource_ids: false,
   resource: EmployeeResource
 {% endhighlight %}
 


### PR DESCRIPTION
in relation to https://github.com/graphiti-api/graphiti/issues/167 and https://github.com/graphiti-api/graphiti/pull/168