### PR TITLE
Update custom types documentation

### DIFF
--- a/_site/guides/concepts/resources.html
+++ b/_site/guides/concepts/resources.html
@@ -373,7 +373,7 @@ data coming in.</p>
     </h5>
   </a>
 
-  <p><a href="https://dry-rb.org/gems/dry-types/custom-types">Dry Types supports custom types</a>. Let’s register a “capital letters” type:</p>
+  <p><a href="https://dry-rb.org/gems/dry-types/1.2/custom-types">Dry Types supports custom types</a>. Let’s register a “capital letters” type:</p>
 
   <figure class="highlight"><pre><code class="language-ruby" data-lang="ruby"><span class="c1"># Define the Type</span>
 <span class="n">definition</span> <span class="o">=</span> <span class="no">Dry</span><span class="o">::</span><span class="no">Types</span><span class="o">::</span><span class="no">Nominal</span><span class="p">.</span><span class="nf">new</span><span class="p">(</span><span class="no">String</span><span class="p">)</span>
@@ -387,7 +387,7 @@ data coming in.</p>
   <span class="ss">read: </span><span class="n">type</span><span class="p">,</span>
   <span class="ss">write: </span><span class="n">type</span><span class="p">,</span>
   <span class="ss">kind: </span><span class="s1">'scalar'</span><span class="p">,</span>
-  <span class="ss">canonical_name: :caps_lock</span><span class="p">,</span>
+  <span class="ss">canonical_name: :string</span><span class="p">,</span>
   <span class="ss">description: </span><span class="s1">'All capital letters'</span>
 <span class="p">}</span>
 


### PR DESCRIPTION
This PR updates the `canonical_name` documentation to reflect the expected value and fixes a broken link.

@richmolj 